### PR TITLE
Support day boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ These settings define the hours the printer may bee when the printer completes.
 These default to 8am - 10pm as I won't likely be checking my printer outside those
 hours.
 
-Note: I don't currently support time windows like 10pm - 8am currently.
-
 ### Beep Settings
 If you want to change the tone, or duration of the beep the printer makes, these
 can be changed to modify that.

--- a/octoprint_FriendlyBeeper/__init__.py
+++ b/octoprint_FriendlyBeeper/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import
-from datetime import datetime
+from datetime import datetime, timedelta
 from time import tzname
 
 import octoprint.plugin
@@ -28,6 +28,12 @@ class FriendlybeeperPlugin(octoprint.plugin.SettingsPlugin,
         # now combine with todays date so we can actually compare
         start = datetime.combine(datetime.now(), start_point.time())
         end = datetime.combine(datetime.now(), end_point.time())
+
+        # if the end time is earlier than the start, add one day to the end.
+        # this covers cases where you want to alert between day boundaries.
+        # e.g.: 8am till 1am.
+        if start > end:
+            end = end + timedelta(days=1)
 
         if start <= now <= end:
             command = "M300 S{frequency} P{duration}".format(


### PR DESCRIPTION
this commit adds support for alarm hours like 8am till 1am. It does this
by adding one day to the end time if the plugin detects that the end
time is earlier than the start time.